### PR TITLE
add delay to get proper error messages on serial monitor

### DIFF
--- a/05-Temperaturmessung/PublishTemperature/PublishTemperature.ino
+++ b/05-Temperaturmessung/PublishTemperature/PublishTemperature.ino
@@ -42,6 +42,7 @@ void reconnect() {
 
 void setup() {
   Serial.begin(115200);
+  delay(100);
   if (!bme.begin(0x76)) {
     Serial.println("Konnte keinen BME280-Sensor finden!");
     while (1)


### PR DESCRIPTION
add delay to get proper error messages on serial monitor because it oftens happens that the output only consists of ⸮⸮⸮⸮⸮⸮⸮⸮⸮⸮